### PR TITLE
Muda rota de subjects para cclasses

### DIFF
--- a/backend/app/controllers/cclasses_controller.rb
+++ b/backend/app/controllers/cclasses_controller.rb
@@ -1,15 +1,15 @@
-class SubjectsController < ApplicationController
+class CclassesController < ApplicationController
   def index
     head :not_found and return if params[:member_id].nil?
     @member = Member.find(params[:member_id])
 
     if !@member.blank?
-      @subjects = []
+      @cclasses = []
       for enrollment in @member.enrollments do
-        @subjects.push(enrollment.cclass.subject)
+        @cclasses.push(enrollment.cclass)
       end
 
-      render json: @subjects
+      render json: @cclasses, include: :subject
     else
       head :not_found
     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,11 +1,10 @@
 Rails.application.routes.draw do
-  get 'subject/index'
   get 'member/show'
   resources :surveys do
     get 'open', on: :collection
   end
   resources :members, only: [:show] do 
-    resources :subjects, only: [:index]
+    resources :cclasses, only: [:index]
   end
   devise_for :user, :path => '/auth', :path_names => { :sign_in => "login", :sign_out => "logout", :sign_up => "register" },
   controllers: {


### PR DESCRIPTION
Modifica requisição `members/:member_id/subjects` para `members/:member_id/cclasses` para facilitar criação de `survey_answers`.

Novo formato de resposta:
```
[
  {
    "id": 1,
    "code": "TA",
    "semester": "2021.2",
    "time": "35T45",
    "subject_id": 1,
    "created_at": "2022-04-23T03:20:08.172Z",
    "updated_at": "2022-04-23T03:20:08.172Z",
    "subject": {
      "id": 1,
      "code": "CIC0097",
      "name": "BANCOS DE DADOS",
      "created_at": "2022-04-23T03:20:07.359Z",
      "updated_at": "2022-04-23T03:20:07.359Z"
    }
  }
]
```