### PR TITLE
Requisição para criação de `survey_answer`

### DIFF
--- a/backend/app/controllers/survey_answers_controller.rb
+++ b/backend/app/controllers/survey_answers_controller.rb
@@ -1,0 +1,43 @@
+class SurveyAnswersController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @current_user = get_user_from_token
+    @member = Member.find(@current_user.member_id)
+
+    head :unprocessable_entity and return if @member.blank?
+      
+    @survey_answer = SurveyAnswer.new(survey_answer_params)
+    @survey_answer.member = @member
+
+    if @survey_answer.save!
+      render json: @survey_answer, include: [:answers => {include: :likert_answers}]
+    else
+      head :unprocessable_entity
+    end
+  end
+
+  private
+
+  # Funcao para decodificar o JWT
+  def get_user_from_token
+    jwt_payload = JWT.decode(request.headers['Authorization'].split(' ')[1], 
+      ENV['JWT_SECRET_KEY']).first
+    user_id = jwt_payload['sub']
+    user = User.find(user_id.to_s)
+  end
+
+  def survey_answer_params
+    params.require(:survey_answer)
+            .permit(
+              :survey_id,
+              :cclass_id,
+              answers_attributes: [
+                :survey_question_id,
+                :content,
+                :question_type,
+                likert_answers_attributes: [:likert_question_id, :content]
+              ]
+            )
+  end
+end

--- a/backend/app/models/answer.rb
+++ b/backend/app/models/answer.rb
@@ -1,5 +1,8 @@
 class Answer < ApplicationRecord
   belongs_to :survey_answer
+  belongs_to :survey_question
+  has_many :likert_answers, dependent: :destroy
+  accepts_nested_attributes_for :likert_answers
 
-  validates :content, presence: true
+  validates :content, presence: true, if: -> { question_type != 'likert_scale' }
 end

--- a/backend/app/models/cclass.rb
+++ b/backend/app/models/cclass.rb
@@ -2,4 +2,5 @@ class Cclass < ApplicationRecord
     belongs_to :subject
     has_many :enrollments
     has_many :members, through: :enrollments
+    has_many :survey_answers
 end

--- a/backend/app/models/likert_answer.rb
+++ b/backend/app/models/likert_answer.rb
@@ -1,0 +1,4 @@
+class LikertAnswer < ApplicationRecord
+    belongs_to :answer
+    belongs_to :likert_question
+end

--- a/backend/app/models/likert_question.rb
+++ b/backend/app/models/likert_question.rb
@@ -1,5 +1,6 @@
 class LikertQuestion < ApplicationRecord
     belongs_to :likert_scale
+    has_many :likert_answers
 
     validates :question, presence: true
 end

--- a/backend/app/models/subject.rb
+++ b/backend/app/models/subject.rb
@@ -2,5 +2,4 @@ class Subject < ApplicationRecord
   validates :code, presence: true, uniqueness: true 
   validates :name, presence: true, uniqueness: true 
   has_many :cclasses
-  has_many :survey_answers
 end

--- a/backend/app/models/survey_answer.rb
+++ b/backend/app/models/survey_answer.rb
@@ -1,6 +1,7 @@
 class SurveyAnswer < ApplicationRecord
   belongs_to :survey
   belongs_to :member
-  belongs_to :subject
+  belongs_to :cclass
   has_many :answers, dependent: :destroy
+  accepts_nested_attributes_for :answers
 end

--- a/backend/app/models/survey_question.rb
+++ b/backend/app/models/survey_question.rb
@@ -2,6 +2,7 @@ class SurveyQuestion < ApplicationRecord
   belongs_to :survey
   has_one :multiple_choice
   has_one :likert_scale
+  has_many :answers
   accepts_nested_attributes_for :multiple_choice, :likert_scale
 
   validates :question, :question_type, presence: true

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'survey_answers/create'
   get 'member/show'
   resources :surveys do
     get 'open', on: :collection

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'survey_answers/create'
   get 'member/show'
   resources :surveys do
     get 'open', on: :collection
@@ -7,6 +6,7 @@ Rails.application.routes.draw do
   resources :members, only: [:show] do 
     resources :cclasses, only: [:index]
   end
+  resources :survey_answers, only: [:create]
   devise_for :user, :path => '/auth', :path_names => { :sign_in => "login", :sign_out => "logout", :sign_up => "register" },
   controllers: {
     sessions: 'users/sessions',

--- a/backend/db/migrate/20220419233135_create_survey_answers.rb
+++ b/backend/db/migrate/20220419233135_create_survey_answers.rb
@@ -3,6 +3,7 @@ class CreateSurveyAnswers < ActiveRecord::Migration[7.0]
     create_table :survey_answers do |t|
       t.belongs_to :survey, foreign_key: true
       t.belongs_to :member, foreign_key: true
+      t.belongs_to :cclass, foreign_key: true
 
       t.timestamps
     end

--- a/backend/db/migrate/20220419233227_create_answers.rb
+++ b/backend/db/migrate/20220419233227_create_answers.rb
@@ -3,6 +3,7 @@ class CreateAnswers < ActiveRecord::Migration[7.0]
     create_table :answers do |t|
       t.text :content
       t.belongs_to :survey_answer, foreign_key: true
+      t.belongs_to :survey_question, foreign_key: true
 
       t.timestamps
     end

--- a/backend/db/migrate/20220424001503_create_likert_answers.rb
+++ b/backend/db/migrate/20220424001503_create_likert_answers.rb
@@ -1,0 +1,11 @@
+class CreateLikertAnswers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likert_answers do |t|
+      t.text :content
+      t.belongs_to :answer, foreign_key: true
+      t.belongs_to :likert_question, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20220424001531_add_question_type_column_to_answers.rb
+++ b/backend/db/migrate/20220424001531_add_question_type_column_to_answers.rb
@@ -1,0 +1,5 @@
+class AddQuestionTypeColumnToAnswers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :answers, :question_type, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,13 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_19_233227) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_24_001531) do
   create_table "answers", force: :cascade do |t|
     t.text "content"
     t.integer "survey_answer_id"
+    t.integer "survey_question_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "question_type"
     t.index ["survey_answer_id"], name: "index_answers_on_survey_answer_id"
+    t.index ["survey_question_id"], name: "index_answers_on_survey_question_id"
   end
 
   create_table "cclasses", force: :cascade do |t|
@@ -44,6 +47,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_19_233227) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["jti"], name: "index_jwt_denylist_on_jti"
+  end
+
+  create_table "likert_answers", force: :cascade do |t|
+    t.text "content"
+    t.integer "answer_id"
+    t.integer "likert_question_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["answer_id"], name: "index_likert_answers_on_answer_id"
+    t.index ["likert_question_id"], name: "index_likert_answers_on_likert_question_id"
   end
 
   create_table "likert_questions", force: :cascade do |t|
@@ -101,8 +114,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_19_233227) do
   create_table "survey_answers", force: :cascade do |t|
     t.integer "survey_id"
     t.integer "member_id"
+    t.integer "cclass_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["cclass_id"], name: "index_survey_answers_on_cclass_id"
     t.index ["member_id"], name: "index_survey_answers_on_member_id"
     t.index ["survey_id"], name: "index_survey_answers_on_survey_id"
   end
@@ -141,13 +156,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_19_233227) do
   end
 
   add_foreign_key "answers", "survey_answers"
+  add_foreign_key "answers", "survey_questions"
   add_foreign_key "cclasses", "subjects"
   add_foreign_key "enrollments", "cclasses"
   add_foreign_key "enrollments", "members"
+  add_foreign_key "likert_answers", "answers"
+  add_foreign_key "likert_answers", "likert_questions"
   add_foreign_key "likert_questions", "likert_scales"
   add_foreign_key "likert_scales", "survey_questions"
   add_foreign_key "multiple_choices", "survey_questions"
   add_foreign_key "options", "multiple_choices"
+  add_foreign_key "survey_answers", "cclasses"
   add_foreign_key "survey_answers", "members"
   add_foreign_key "survey_answers", "surveys"
   add_foreign_key "survey_questions", "surveys"

--- a/backend/spec/models/likert_answer_spec.rb
+++ b/backend/spec/models/likert_answer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LikertAnswer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Cria endpoint `/survey_answers` para uma requisição de tipo POST para criação de um `suvey_answer`. Resolve issue #25 

Exemplo de formato para uma requisição para `/survey_answers`
```
{
  "survey_id": 1,
  "cclass_id": 1,
  "answers_attributes": [
    {
      "suvey_question_id": 1,
      "quesiton_type": "discursive",
      "content": "resposta"
    },
    {
      "survey_question_id": 2,
      "question_type": "multiple_choice",
      "content": "Opção 1"
    },
    {
      "survey_question_id": 3,
      "question_type": "likert_scale",
      "likert_answers_attributes": [
        {
          "likert_question_id": 1,
          "content": "Concordo parcialmente"
        },
        {
          "likert_question_id": 2,
          "content": "Discordo totalmente"
        }
      ]
    }
  ]
}
```